### PR TITLE
#14 Feat: Crear conexiones de persistencia para la BD 

### DIFF
--- a/backend/src/modules/gestion_academica/domain/entities/classes.entity.ts
+++ b/backend/src/modules/gestion_academica/domain/entities/classes.entity.ts
@@ -3,7 +3,7 @@ export class Classes {
         public readonly id: string,
         public name: string,
         public semester: string,
-        public teacherId: number,
+        public teacherId: string,
         public isActive: boolean,
         public dateBegin: Date,
         public dateEnd: Date,

--- a/backend/src/modules/gestion_academica/infrastructure/persistence/classes.prisma.repository.ts
+++ b/backend/src/modules/gestion_academica/infrastructure/persistence/classes.prisma.repository.ts
@@ -1,0 +1,73 @@
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../../../../core/prisma/prisma.service";
+import { ClassesRepositoryPort } from "../../domain/ports/classes.repository.ports";
+import { Classes } from "../../domain/entities/classes.entity";
+
+@Injectable()
+export class ClassesPrismaRepository implements ClassesRepositoryPort {
+    constructor(private readonly prisma: PrismaService) { }
+
+    async findById(id: string): Promise<Classes | null> {
+        const classesData = await this.prisma.classes.findUnique({ where: { id } });
+        if (!classesData) return null;
+        return new Classes(
+            classesData.id,
+            classesData.name,
+            classesData.semester,
+            classesData.teacherId,
+            classesData.isActive,
+            new Date(classesData.dateBegin),
+            new Date(classesData.dateEnd)
+        )
+    }
+
+    async findByTeacherId(teacherId: string): Promise<Classes[]> {
+        const classesData = await this.prisma.classes.findMany({ where: { teacherId } });
+        if (!classesData) return [];
+        return classesData.map(c => new Classes(
+            c.id,
+            c.name,
+            c.semester,
+            c.teacherId,
+            c.isActive,
+            new Date(c.dateBegin),
+            new Date(c.dateEnd)
+        ));
+    };
+
+    async create(name: string, semester: string, teacherId: string, dateBegin: Date, dateEnd: Date): Promise<Classes> {
+        const newClass = await this.prisma.classes.create({
+            data: {
+                name,
+                semester,
+                teacherId,
+                isActive: true,
+                dateBegin,
+                dateEnd
+            }
+        });
+        return new Classes(
+            newClass.id,
+            newClass.name,
+            newClass.semester,
+            newClass.teacherId,
+            newClass.isActive,
+            new Date(newClass.dateBegin),
+            new Date(newClass.dateEnd)
+        );
+    }
+
+    async list(): Promise<Classes[]> {
+        const rows = await this.prisma.classes.findMany({ orderBy: { name: 'asc' } });
+        return rows.map((c) => new Classes(
+            c.id,
+            c.name,
+            c.semester,
+            c.teacherId,
+            c.isActive,
+            new Date(c.dateBegin),
+            new Date(c.dateEnd)
+        ));
+    }
+
+}

--- a/backend/src/modules/gestion_academica/infrastructure/persistence/enrollment.prisma.repository.ts
+++ b/backend/src/modules/gestion_academica/infrastructure/persistence/enrollment.prisma.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { EnrollmentRepositoryPort } from '../../domain/ports/enrollment.repository.ports';
+import { Enrollment } from '../../domain/entities/enrollment.entity';
+
+@Injectable()
+export class EnrollmentPrismaRepository implements EnrollmentRepositoryPort {
+    constructor(private readonly prisma: PrismaService) { }
+
+    async findByStudentId(studentId: string): Promise<Enrollment[]> {
+        const enrollmentData = await this.prisma.enrollment.findMany({ where: { studentId } });
+        if (!enrollmentData) return [];
+        return enrollmentData.map(e => new Enrollment(
+            e.studentId,
+            e.classId,
+            e.isActive
+        ));
+    };
+
+    async findByClassId(classId: string): Promise<Enrollment[]> {
+        const enrollmentData = await this.prisma.enrollment.findMany({ where: { classId } });
+        if (!enrollmentData) return [];
+        return enrollmentData.map(e => new Enrollment(
+            e.studentId,
+            e.classId,
+            e.isActive
+        ));
+    };
+
+    async create(studentId: string, classId: string): Promise<Enrollment> {
+        const newEnrollment = await this.prisma.enrollment.create({
+            data: {
+                studentId,
+                classId,
+                isActive: true
+            }
+        });
+        return new Enrollment(
+            newEnrollment.studentId,
+            newEnrollment.classId,
+            newEnrollment.isActive
+        );
+    }
+
+    async list(): Promise<Enrollment[]> {
+        const rows = await this.prisma.enrollment.findMany();
+        return rows.map((e) => new Enrollment(
+            e.studentId,
+            e.classId,
+            e.isActive
+        ));
+    };
+
+
+}

--- a/backend/src/modules/gestion_academica/infrastructure/persistence/student.prisma.repository.ts
+++ b/backend/src/modules/gestion_academica/infrastructure/persistence/student.prisma.repository.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { StudentRepositoryPort } from '../../domain/ports/student.repository.ports';
+import { Student } from '../../domain/entities/student.entity';
+
+@Injectable()
+export class StudentPrismaRepository implements StudentRepositoryPort {
+    constructor(private readonly prisma: PrismaService) { }
+
+    async findByUserId(userId: string): Promise<Student | null> {
+        const student = await this.prisma.studentProfile.findUnique({ where: { userId } });
+        if (!student) return null;
+        return new Student(
+            student.userId,
+            student.code,
+            student.career || undefined,
+            student.admissionYear || undefined
+        );
+    };
+
+    async create(userId: string, code: number, career?: string, admissionYear?: number): Promise<Student> {
+        const newStudent = await this.prisma.studentProfile.create({
+            data: {
+                userId,
+                code,
+                career,
+                admissionYear
+            }
+        });
+        return new Student(
+            newStudent.userId,
+            newStudent.code,
+            newStudent.career || undefined,
+            newStudent.admissionYear || undefined
+        );
+    }
+
+    async list(): Promise<Student[]> {
+        const rows = await this.prisma.studentProfile.findMany();
+        return rows.map((s) => new Student(
+            s.userId,
+            s.code,
+            s.career || undefined,
+            s.admissionYear || undefined
+        ));
+    };
+}

--- a/backend/src/modules/gestion_academica/infrastructure/persistence/teacher.prisma.repository.ts
+++ b/backend/src/modules/gestion_academica/infrastructure/persistence/teacher.prisma.repository.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../core/prisma/prisma.service';
+import { ProfessorRepositoryPort } from '../../domain/ports/teacher.repository.ports';
+import { Teacher } from '../../domain/entities/teacher.entity';
+
+@Injectable()
+export class TeacherPrismaRepository implements ProfessorRepositoryPort {
+    constructor(private readonly prisma: PrismaService) {};
+
+    async findByUserId(userId: string): Promise<Teacher | null> {
+        const teacher = await this.prisma.teacherProfile.findUnique({ where: { userId } });
+        if (!teacher) return null;
+        return new Teacher(
+            teacher.userId,
+            teacher.academicUnit || undefined,
+            teacher.title || undefined,
+            teacher.bio || undefined
+        );
+    }
+
+    async create(userId: string, academicUnit?: string, title?: string, bio?: string): Promise<Teacher> {
+        const newTeacher = await this.prisma.teacherProfile.create({
+            data: {
+                userId,
+                academicUnit,
+                title,
+                bio
+            }
+        });
+        return new Teacher(
+            newTeacher.userId,
+            newTeacher.academicUnit || undefined,
+            newTeacher.title || undefined,
+            newTeacher.bio || undefined
+        );
+    };
+
+    async list(): Promise<Teacher[]> {
+        const rows = await this.prisma.teacherProfile.findMany();
+        return rows.map((t) => new Teacher(
+            t.userId,
+            t.academicUnit || undefined,
+            t.title || undefined,
+            t.bio || undefined
+        ))
+    };
+    
+}


### PR DESCRIPTION
- Corrección menor al tipo de dato del ID de docente en `classes.entity.ts`
- Se implementaron los adapters del directorio `persistence` para: Teacher, Student, Classes, Enrollment