### PR TITLE
Us007/joack/fix/class form

### DIFF
--- a/client/src/components/CreatePeriodForm.tsx
+++ b/client/src/components/CreatePeriodForm.tsx
@@ -256,6 +256,8 @@ export function CreatePeriodForm({
             value={formik.values.semester}
             onChange={(value) => {
               formik.setFieldValue("semester", value);
+              formik.setFieldValue("dateBegin", "");
+              formik.setFieldValue("dateEnd", "");
             }}
             onBlur={() => formik.setFieldTouched("semester", true)}
             style={{ width: "100%" }}
@@ -293,6 +295,12 @@ export function CreatePeriodForm({
                 ? dayjs(formik.values.dateBegin)
                 : undefined
             }
+            defaultPickerValue={
+              formik.values.semester
+                ? ranges[formik.values.semester].start
+                : undefined
+            }
+            disabled={!formik.values.semester}
             disabledDate={disabledDateBegin}
             onChange={(value) => handleDateChange("dateBegin", value)}
           />
@@ -314,6 +322,12 @@ export function CreatePeriodForm({
             value={
               formik.values.dateEnd ? dayjs(formik.values.dateEnd) : undefined
             }
+            defaultPickerValue={
+              formik.values.semester
+                ? ranges[formik.values.semester].start
+                : undefined
+            }
+            disabled={!formik.values.dateBegin}
             disabledDate={disabledDateEnd}
             onChange={(value) => handleDateChange("dateEnd", value)}
           />

--- a/client/src/components/CreatePeriodForm.tsx
+++ b/client/src/components/CreatePeriodForm.tsx
@@ -89,6 +89,15 @@ export function CreatePeriodForm({
     },
   });
 
+  const disabledDateBegin = (current: Dayjs) => {
+    return current && current.isBefore(dayjs().subtract(1, "day"));
+  };
+
+  const disabledDateEnd = (current: Dayjs) => {
+    if (!formik.values.dateBegin) return false;
+    return current && current.isBefore(dayjs(formik.values.dateBegin));
+  };
+
   const handleCancel = () => {
     onClose();
     formik.resetForm();
@@ -157,11 +166,7 @@ export function CreatePeriodForm({
                 ? dayjs(formik.values.dateBegin)
                 : undefined
             }
-            disabledDate={(current: Dayjs) => {
-              const threeWeeksAgo = new Date();
-              threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 21);
-              return current && current.toDate() < threeWeeksAgo;
-            }}
+            disabledDate={disabledDateBegin}
             onChange={(value) => {
               const date = value?.toDate();
               if (date) {
@@ -193,12 +198,7 @@ export function CreatePeriodForm({
             value={
               formik.values.dateEnd ? dayjs(formik.values.dateEnd) : undefined
             }
-            disabledDate={(current: Dayjs) => {
-              if (!formik.values.dateBegin) return false;
-              return (
-                current && current.toDate() <= new Date(formik.values.dateBegin)
-              );
-            }}
+            disabledDate={disabledDateEnd}
             onChange={(value) => {
               const date = value?.toDate();
               if (date) {


### PR DESCRIPTION
Se mejoró la funcionalidad para crear períodos académicos dentro de un curso, incluyendo el formulario, validaciones y manejo de fechas. Los cambios principales fueron:

- Mínimo de 25 días hábiles por período (se puede cambia la constante MIN_BUSINESS_DAYS).
- Cálculo automático de fechas habilitadas según el semestre seleccionado:
- Al seleccionar la fecha de inicio, se asigna automáticamente una fecha de fin sugerida según MIN_BUSINESS_DAYS.
- La fecha de inicio tiene que ser por lo menos 25 días antes de la fecha final del semestre.
- La fecha de fin tiene que ser por lo menos 25 días después de la fecha de inicio del semestre.
- Mensajes de error.