### PR TITLE
US003 - Feat: Conexión del frontend con el backend para endpoint de guardado de asistencia

### DIFF
--- a/client/src/hooks/useAttendance.ts
+++ b/client/src/hooks/useAttendance.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { useUserStore } from "../store/userStore";
+import type { CreateAttendanceInterface } from "../interfaces/attendanceInterface";
+import { attendanceService } from "../services/attendance.service";
+
+const useAttendance = () => {
+    const user = useUserStore((s) => s.user);
+    const fetchUser = useUserStore((s) => s.fetchUser);
+
+    useEffect(() => {
+        const prepareHook = async () => {
+            if (!user) {
+                await fetchUser();
+            };
+        };
+        prepareHook();
+    }, [user]);
+
+    //Endpoints POST
+    const saveAttendanceList = async (attendanceInfo: Omit<CreateAttendanceInterface, "teacherId">) => {
+        if (!user) return {
+            state: "error",
+            message: "No se ha podido cargar la información del usuario"
+        };
+
+        const classId = attendanceInfo.classId;
+        const attendanceData = {
+            teacherId: user.id,
+            date: attendanceInfo.date,
+            attendances: attendanceInfo.attendances
+        };
+        const res = await attendanceService.saveAttendanceList(classId, attendanceData);
+        const success = res?.code === 201
+        return {
+            state: success ? "success" : "error",
+            message: success ? "Asistencia guardada correctamente" : res?.error
+        };
+    }
+
+    return {
+        saveAttendanceList,
+    }
+}
+
+export default useAttendance;

--- a/client/src/interfaces/attendanceInterface.ts
+++ b/client/src/interfaces/attendanceInterface.ts
@@ -1,0 +1,11 @@
+export interface CreateAttendanceInterface {
+    classId: string,
+    teacherId: string,
+    date: Date,
+    attendances: AttendanceRow[]
+}
+
+export interface AttendanceRow {
+    studentId: string,
+    isPresent?: boolean,
+}

--- a/client/src/services/attendance.service.ts
+++ b/client/src/services/attendance.service.ts
@@ -1,0 +1,16 @@
+import apiClient from "../api/apiClient";
+import type { CreateAttendanceInterface } from "../interfaces/attendanceInterface";
+
+export const attendanceService = {
+    //Enpoints POST
+    async saveAttendanceList(classId: string, attendanceData: Omit<CreateAttendanceInterface, "classId">) {
+        try {
+            const response = await apiClient.post(`/academic/attendance/${classId}`, attendanceData);
+            return response.data;
+        } catch (error) {
+            console.error("Failed to enroll student in class", error);
+            throw error;
+        }
+    },
+    
+}


### PR DESCRIPTION
- Se agregó el hook para asistencia `useAttendance` y la preparación de datos para el endpoint en desarrollo para el guardado de asistencia
- Se agregó el service de asistencia y su conexión con el endpoint POST de guardado de asistencia, se envía el classId en los params y el resto de la información en el Body
- Se agregaron interfaces para asegurar la estructura de los archivos a emplear en las solicitudes

>[!Important]
>De momento todos los archivos cuentan con soporte solo para el endpoint de guardado de asistencia, pero pueden modificarse sin problema para los próximos endpoints