### PR TITLE
Fix[US005] spelling change in the course card message

### DIFF
--- a/client/src/pages/courses/TeacherCoursePage.tsx
+++ b/client/src/pages/courses/TeacherCoursePage.tsx
@@ -150,7 +150,7 @@ export function TeacherCoursePage() {
                       title={course.name}
                     />
                     <CustomCard.Description>
-                      {`Vea a detalle los periodos que ha dictado en ${course.name}`}
+                      {`Vea a detalle los períodos que ha dictado en ${course.name}`}
                     </CustomCard.Description>
                     <CustomCard.Actions>
                       <Button


### PR DESCRIPTION
cambio un error ortografico en la card de materias en la palabra periodos a períodos con tilde